### PR TITLE
330557 shared snippets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This DaVinci package contains a module which is meant to
     (modified) evaluation of Drug-Induced Serious Hepatotoxicity plot.
 License: Apache License (>= 2)
 Depends: 
-    R (>= 4.0)
+    R (>= 4.1)
 Imports:
     checkmate (>= 2.1.0),
     dplyr (>= 1.0.5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dv.edish
 Title: eDISH Plot Module for DILI assessment
-Version: 2.0.1
+Version: 2.0.1-9000
 Authors@R: c(
     person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
     person("Isabel", "Glauss", , "isabel.glauss@boehringer-ingelheim.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.edish 2.0.1-9000
+
+- [NOT USER-FACING] Update communication with papo test snippet
+
 # dv.edish 2.0.1
 
 - Reinstate UI selection of liver function parameter on y-axis.

--- a/inst/validation/specs.R
+++ b/inst/validation/specs.R
@@ -33,5 +33,6 @@ framework_specs <- specs_list(
 specs <- specs_list(
   input_menu_specs = input_menu_specs,
   plot_specs = plot_specs,
-  framework_specs = framework_specs
+  framework_specs = framework_specs,
+  jumping_feature = "Jump-to-subject feature."
 )

--- a/inst/validation/specs.R
+++ b/inst/validation/specs.R
@@ -33,6 +33,5 @@ framework_specs <- specs_list(
 specs <- specs_list(
   input_menu_specs = input_menu_specs,
   plot_specs = plot_specs,
-  framework_specs = framework_specs,
-  jumping_feature = "Jump-to-subject feature."
+  framework_specs = framework_specs
 )

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -12,9 +12,7 @@ vdoc <- local({
 specs <- vdoc[["specs"]]
 #  validation (F)
 
-
-
-# YT#VH27d48516d3cbdadbf92a7b5e0860b78e#VH19ec235e56cdd18f129215603abf0ca6#
+# YT#VH0bf15c0db690dfd3fac713f3c9b61f66#VH00000000000000000000000000000000#
 
 #' Test harness for communication with `dv.papo`.
 #'
@@ -22,7 +20,7 @@ specs <- vdoc[["specs"]]
 #' @param data Data matching the previous parameterization.
 #' @param trigger_input_id Fully namespaced input ID that, when set to a subject ID value,
 #'                         should make the module send `dv.papo` a message.
-test_communication_with_papo <- function(mod, data, trigger_input_id) {
+test_communication_with_papo <- function(mod, data, trigger_input_id, papo_spec_id, papo_spec_text) {
   datasets <- shiny::reactive(data)
 
   afmm <- list(
@@ -55,7 +53,7 @@ test_communication_with_papo <- function(mod, data, trigger_input_id) {
   app <- shiny::shinyApp(ui = app_ui, server = app_server)
 
   testthat::test_that("module adheres to send_subject_id_to_papo protocol" |>
-    vdoc[["add_spec"]](specs$framework_specs$jumping_feature), {
+    vdoc[["add_spec"]](papo_spec_text, papo_spec_id), {
     app <- shinytest2::AppDriver$new(app, name = "test_send_subject_id_to_papo_protocol")
 
     app$wait_for_idle()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -56,7 +56,7 @@ test_communication_with_papo <- function(mod, data, trigger_input_id, papo_spec_
     vdoc[["add_spec"]](papo_spec_text, papo_spec_id), {
     app <- shinytest2::AppDriver$new(app, name = "test_send_subject_id_to_papo_protocol")
 
-    app$wait_for_value(export = "update_count")
+    app$wait_for_idle()
 
     # Module starts and sends no message
     exports <- app$get_values()[["export"]]

--- a/tests/testthat/test-06-jumping.R
+++ b/tests/testthat/test-06-jumping.R
@@ -14,4 +14,4 @@ mod <- dv.edish::mod_edish(
 )
 
 trigger_input_id <- "mod-plot_selected"
-test_communication_with_papo(mod, data_list, trigger_input_id)
+test_communication_with_papo(mod, data_list, trigger_input_id, "jumping_feature", specs$jumping_feature)

--- a/tests/testthat/test-06-jumping.R
+++ b/tests/testthat/test-06-jumping.R
@@ -14,4 +14,5 @@ mod <- dv.edish::mod_edish(
 )
 
 trigger_input_id <- "mod-plot_selected"
-test_communication_with_papo(mod, data_list, trigger_input_id, "jumping_feature", specs$jumping_feature)
+test_communication_with_papo(mod, data_list, trigger_input_id, 
+                             "framework_specs$jumping_feature", specs$framework_specs$jumping_feature)


### PR DESCRIPTION
This small change syncs the "communication with papo" shared snippet with the rest of the dv.* modules that use it.

Please note that this change reverts a recent change to the line:
> app$wait_for_value(export = "update_count")

back to:
> app$wait_for_idle()

The `update_count` exported field is readily available as soon as the `app_server` returns (on [line 50](https://github.com/Boehringer-Ingelheim/dv.edish/blob/264f2ae7ebe40cce459139bdccca2a6d799e5827/tests/testthat/setup.R#L50)), because it communicates the initial value of a `reactiveVal` (`ret_value_update_count`) that doesn't need to wait for the execution of any reactive. This means that the `wait_for_value` version will wait for strictly shorter amount of time than the `wait_for_idle` version.
   Waiting for idle, while an imperfect tool, is more conservative. It will wait some extra time for the reactivity of the module to settle and thus it will allow the module to catch possible spurious updates to the return value (the ones counted through `update_count`).


# Critical checks

- [x] Is the test version number correct (x.x.x-9000)? 

- [x] DESCRIPTION file

- [x] NEWS.md

- [x] Does the build pass?

---

## Documentation

Does it include the following sections?

- [x] Module introduction with features
  - [ ] (O) Screenshots

- [ ] Installation details

- [ ] Explanation of function arguments

- [ ] Data specifications and requirements

- [ ] Different possible visualizations

- [x] Are the changes/new features included in NEWS.md?
  - [ ] (O) Screenshots

- [ ] (O) Explanation of input menus

- [ ] (O) Short articles on building the app, compatibility with other modules, known bugs,...

---

## QC Report

- [x] Does it include a QC Report with positive outcome?

- [x] Are the new features reflected accordingly in the specs?

---

## API conventions

- [x] Follows API convention

